### PR TITLE
Feat: 이미지 리사이즈 압축 품질을 80으로 설정하여 파일 크기 최적화

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,7 +13,7 @@ export const resizeFile = (file: Blob): Promise<string> =>
       800,
       800,
       "WEBP",
-      100,
+      80,
       0,
       (uri) => {
         resolve(URL.createObjectURL(uri as Blob));


### PR DESCRIPTION
- 이미지를 리사이징 했음에도 파일 크기가 크게 줄어들지 않았음.
- 이미지 리사이징 시, 압축 품질도 함께 조정하여 파일 크기를 최적화하였음.
- 같은 파일을 업로드 했을 때, 압축 품질 100에서 80으로 조정했을 경우, 408.88KB -> 42KB로 약 89.73%(9.74배) 감소
- <img width="1090" alt="스크린샷 2024-11-06 오전 1 38 52" src="https://github.com/user-attachments/assets/9e788b31-2e63-4b3a-9b66-4993c8b5cb85">